### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/tests/e2e/features/redirection/loginPage/redirection.feature
+++ b/tests/e2e/features/redirection/loginPage/redirection.feature
@@ -23,6 +23,6 @@ Feature: External Redirection on the Login Page
       | aria-label    | Blog                | https://zksync.mirror.xyz/                                        |
       | aria-label    | Discord Community   | https://join.zksync.dev/                                          |
       | aria-label    | Telegram Support    | https://t.me/zksync                                               |
-      | aria-label    | Twitter Community   | https://twitter.com/i/flow/login?redirect_after_login=%2Fzksync   |
+      | aria-label    | Twitter Community   | https://x.com/i/flow/login?redirect_after_login=%2Fzksync   |
       | aria-label    | Email               | https://zksync.io/contact                                         |
       

--- a/tests/e2e/features/redirection/mainPage/redirection.feature
+++ b/tests/e2e/features/redirection/mainPage/redirection.feature
@@ -52,7 +52,7 @@ Feature: External Redirection on the Main Page
       | aria-label    | Blog               | https://zksync.mirror.xyz/                                        |
       | aria-label    | Discord Community  | https://join.zksync.dev/                                          |
       | aria-label    | Telegram Support   | https://t.me/zksync                                               |
-      | aria-label    | Twitter Community  | https://twitter.com/i/flow/login?redirect_after_login=%2Fzksync   |
+      | aria-label    |  Community  | https://x.com/i/flow/login?redirect_after_login=%2Fzksync   |
       | aria-label    | Email              | https://zksync.io/contact                                         |
 
   @id1535:II


### PR DESCRIPTION
Updated the Twitter URL from https://twitter.com to https://x.com to reflect the platform's rebranding.